### PR TITLE
Add logger interface and default implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ This project was created to control smarthome devices (e.g. [Homematic](http://w
 
 ## Requirements
 
-- Of cause, all those [prerequisites to Smart Home Skill Development](https://developer.amazon.com/de/docs/smarthome/understand-the-smart-home-skill-api.html#prerequisites-to-smart-home-skill-development) whould be very helpful
-- I asume you authenticate an Alexa user with [LWA](https://developer.amazon.com/de/docs/smarthome/authenticate-an-alexa-user-account-linking.html). To support other OAuth2 providers, you need to add a [custom directive processor](#custom-directive-processor) to handle authentication directives.
+- Of course, all those [prerequisites to Smart Home Skill Development](https://developer.amazon.com/de/docs/smarthome/understand-the-smart-home-skill-api.html#prerequisites-to-smart-home-skill-development) whould be very helpful
+- I asume you authenticate an Alexa user by using [LWA](https://developer.amazon.com/de/docs/smarthome/authenticate-an-alexa-user-account-linking.html). To support other OAuth2 providers, you need to add a [custom directive processor](#custom-directive-processor) to handle authentication directives.
 
 ## Installation
 
@@ -135,6 +135,10 @@ And add it to the previously created handler.
 handler.AddDirectiveProcessor(CustomDirectiveProcessor{})
 ```
 
+### Logging
+
+By default only errors get logged to `stderr`. Change default logging behaviour by creating a new instance with custom writer and severenity by using `smarthome.NewDefaultLogger(...)`. Alternativly assign a custom `smarthome.Logger` implementation to `smarthome.Log` to override logging for your needs. 
+
 ## FAQ
 
 t.b.d.
@@ -143,7 +147,6 @@ t.b.d.
 
 - Support asynchronous responses and automatically use them if processing a directive takes to long
 - Looking forward to find a better way to control window blinds (instead of simply turning them on and off)
-- Find a better way for logging, avoid using static `log.Printf()`
 
 ## License
 

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -41,7 +41,7 @@ func Example() {
 
 		// Optionally we set a validator instance. Because alexa wont work with non well-formed
 		// responses, this is especially helpful for debugging. The validation result will be
-		// logged by using go stdlib log.Print() method.
+		// logged as warning.
 		Validator: &validator.Validator{},
 	}
 

--- a/smarthome/authority.go
+++ b/smarthome/authority.go
@@ -2,7 +2,6 @@ package smarthome
 
 import (
 	"errors"
-	"log"
 )
 
 // Authority to handle alexa user authorization
@@ -33,7 +32,7 @@ func (a Authority) AcceptGrant(email string, bearerToken string, accessTokens ma
 
 	// todo, hold the token for async responses and refresh after the given time
 	//log.Printf("Granted access to %s.\nAccess tokens:%s", email, accessTokens)
-	log.Printf("Granted access to %s.", email)
+	Log.Info("Granted access to %s.", email)
 
 	return nil
 }

--- a/smarthome/logger.go
+++ b/smarthome/logger.go
@@ -1,0 +1,104 @@
+package smarthome
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+)
+
+// Logger interface
+type Logger interface {
+	Trace(format string, v ...interface{})
+	Debug(format string, v ...interface{})
+	Info(format string, v ...interface{})
+	Warning(format string, v ...interface{})
+	Error(format string, v ...interface{})
+	Fatal(format string, v ...interface{})
+}
+
+// Severe level to create new default logger
+const (
+	Trace = iota
+	Debug
+	Info
+	Warning
+	Error
+	Fatal
+)
+
+type defaultLogger struct {
+	Level  int
+	stdLog *log.Logger
+}
+
+// Log is the Logger implementation got used for logging
+var Log = NewDefaultLogger(Error, os.Stderr)
+
+// NewDefaultLogger creates a default Logger implemtation uses stdlib log with default flags
+func NewDefaultLogger(level int, out io.Writer) Logger {
+	return &defaultLogger{
+		Level:  level,
+		stdLog: log.New(out, "", log.LstdFlags),
+	}
+}
+
+// Trace message
+func (logger defaultLogger) Trace(format string, v ...interface{}) {
+	if logger.Level > Trace {
+		return
+	}
+
+	logger.log("TRACE", format, v...)
+}
+
+// Debug message
+func (logger defaultLogger) Debug(format string, v ...interface{}) {
+	if logger.Level > Debug {
+		return
+	}
+
+	logger.log("DEBUG", format, v...)
+}
+
+// Info message
+func (logger defaultLogger) Info(format string, v ...interface{}) {
+	if logger.Level > Info {
+		return
+	}
+
+	logger.log("INFO", format, v...)
+}
+
+// Warning message
+func (logger defaultLogger) Warning(format string, v ...interface{}) {
+	if logger.Level > Warning {
+		return
+	}
+
+	logger.log("WARN", format, v...)
+}
+
+// Error message
+func (logger defaultLogger) Error(format string, v ...interface{}) {
+	if logger.Level > Error {
+		return
+	}
+
+	logger.log("ERROR", format, v...)
+}
+
+// Fatal message
+func (logger defaultLogger) Fatal(format string, v ...interface{}) {
+	logger.log("FATAL", format, v...)
+}
+
+func (logger defaultLogger) log(level, format string, v ...interface{}) {
+	message := fmt.Sprintf(format, v...)
+	if strings.HasSuffix(message, "\n") {
+		message = message[:len(message)-1]
+	}
+
+	logger.stdLog.Printf("[go-alexa] [%s] %s\n", level, message)
+}

--- a/smarthome/logger_test.go
+++ b/smarthome/logger_test.go
@@ -1,0 +1,57 @@
+package smarthome_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/betom84/go-alexa/smarthome"
+)
+
+func TestDefaultLoggerForTraceLevel(t *testing.T) {
+
+	builder := &strings.Builder{}
+	logger := smarthome.NewDefaultLogger(smarthome.Trace, builder)
+
+	logger.Trace("This is a trace message")
+	assert.True(t, strings.HasSuffix(builder.String(), "[go-alexa] [TRACE] This is a trace message\n"))
+	builder.Reset()
+
+	logger.Debug("This is a debug message")
+	assert.True(t, strings.HasSuffix(builder.String(), "[go-alexa] [DEBUG] This is a debug message\n"))
+	builder.Reset()
+
+	logger.Info("This is a info message")
+	assert.True(t, strings.HasSuffix(builder.String(), "[go-alexa] [INFO] This is a info message\n"))
+	builder.Reset()
+
+	logger.Warning("This is a warning message")
+	assert.True(t, strings.HasSuffix(builder.String(), "[go-alexa] [WARN] This is a warning message\n"))
+	builder.Reset()
+
+	logger.Error("This is a %s message\n", "error")
+	assert.True(t, strings.HasSuffix(builder.String(), "[go-alexa] [ERROR] This is a error message\n"))
+	builder.Reset()
+
+	logger.Fatal("This is a %s message\n", "fatal")
+	assert.True(t, strings.HasSuffix(builder.String(), "[go-alexa] [FATAL] This is a fatal message\n"))
+	builder.Reset()
+}
+
+func TestDefaultLoggerForFatalLevel(t *testing.T) {
+
+	builder := &strings.Builder{}
+	logger := smarthome.NewDefaultLogger(smarthome.Fatal, builder)
+
+	logger.Trace("This is a trace message")
+	logger.Debug("This is a debug message")
+	logger.Info("This is a info message")
+	logger.Warning("This is a warning message\n")
+	logger.Error("This is a %s message\n", "error")
+	assert.Equal(t, 0, builder.Len())
+
+	logger.Fatal("This is a %s message\n", "fatal")
+	assert.True(t, strings.HasSuffix(builder.String(), "[go-alexa] [FATAL] This is a fatal message\n"))
+	builder.Reset()
+}


### PR DESCRIPTION
Add logger to avoid using log.Printf() directly and be able to override logging behaviour. The logger implementation used by default will log only errors to stderr.